### PR TITLE
SELIC added to test graphs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/pages/comparacao.tsx
+++ b/src/pages/comparacao.tsx
@@ -221,6 +221,18 @@ export default function Comparacao() {
           }),
     };
 
+    const SELIC = {
+      label: 'SELIC',
+      backgroundColor: theme.colors.iconSelected,
+      borderColor: theme.colors.iconSelected,
+      spanGaps: true,
+      data: isToHiddenCDI
+        ? []
+        : cdiRentab.rentab.map((rentab: any) => {
+            return { x: formatDate(rentab.date), y: rentab.diff };
+          }),
+    };
+
     if (isToHiddenCDI) {
       const firstFund = rentabFunds[0];
       const labels = firstFund.rentab.map((data: any) => formatDate(data.x));
@@ -231,7 +243,7 @@ export default function Comparacao() {
       const labels = cdiRentab.rentab.map((data: any) => formatDate(data.x));
 
       setLabels(labels);
-      setDatasets([...datasets, CDI]);
+      setDatasets([...datasets, CDI, SELIC]);
     }
   }, [rentabFunds, selectedFunds, isToHiddenCDI]);
 


### PR DESCRIPTION
# SELIC rate added in frontend Graphs

The Selic rate chart has been added for comparison against current selected funds and CDI.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] Needs to be tested to see the relationship between SELIC and CDI (which at the moment appear to be similar)